### PR TITLE
Add @remix-run/node to dependencies to fix crash during postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "start": "firebase emulators:start"
   },
   "dependencies": {
+    "@remix-run/node": "^1.5.1",
     "@remix-run/react": "^1.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
Fixes #1 

Steps:
1. `npm install`
2. Verify npm install completes successfully